### PR TITLE
default local development to Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,133 @@
 Data analytics template
 ================
 
+> Lightweight but compatible version of [ML Ops template](https://github.com/Datahel/mlops-template) for analytics & experimental work.
+
 This template contains basic tools and environment for data analytics using python libraries and Jupyter Notebooks.
 
 Initialize new repository using this template. Use this document as base
 for your projects documentation.
 
+## Creating a new repo from this template
+
+For your D/A/ML project, create new repo from this template ([see GitHub instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)). Commit history will be cleaned and the authors won't have access to your new repository (although sharing your work is encouraged).
+
+> NOTE: Updates to the template cannot be automatically synchronized to child projects!
+
+Checklist for creating the repository:
+1. Use dashes '-' instead of underscores '_' for the repository name. This is an [nbdev](https://nbdev.fast.ai) convention.
+2. Set your organization as the owner, if you represent one.
+3. Once the repository is ready, edit nbdev config file `settings.ini` & `ml_pipe/Makefile` according to your project information. The `lib_path` variable should be set to `nbs/your_repository_name_but_with_underscores_instead_of_dashes`.
+
+
+## Working with the template:
+
+The template assumes working within containers. Non-container development is possible but not recommended. 
+
+### Option 1: Codespaces
+
+Repositories generated from the template are development-ready with [GitHub Codespaces](https://docs.github.com/en/codespaces/overview).
+
+Codespaces builds a container according to settings in `.devcontainer/devcontainer.json` and attaches to it in `vsc` mode (see 'Running the container' below).
+
+Just launch your repository in a Codespace and start working.
+
+### Option 2: Local
+
+
+Begin by selecting your tools. Here are two examples for local development: Podman + JupyterLab (recommended), and Docker + VSC (*Visual Studio Code*).
+
+The template container has two modes for development `vsc` (default) and `jupyterlab`. The mode is given an environment variable `MODE` when running the container.
+
+*Podman + JupyterLab*
+
+Podman is an open source container runtime tool, that can also operate Docker containers, and shares most of the syntax with Docker. While it is possible to configure VSC Dev Container or VSC Remote Container to use Podman or other open source container framework (see instructions with [minikube](https://benmatselby.dev/post/vscode-dev-containers-minikube/) or [Podman desktop](https://developers.redhat.com/articles/2023/02/14/remote-container-development-vs-code-and-podman#)), this requires some effort compared to Docker with Docker Desktop. In addition, third party Docker extensions may not work. Therefore, it is recommended to develop locally with Jupyterlab, which comes installed within the template container.
+
+```bash
+# On MacOS
+
+# Install podman, docker and hyperkit
+# These are the only requirements for your system - 
+# everything else, including python and it's packages 
+# are installed within the container!
+
+$ brew install hyperkit
+$ brew install docker docker-compose
+$ brew install podman podman-compose
+$ brew install podman-desktop
+    
+# Init podman machine and allocate resources
+# NOTE: edit the allocation according to your needs.
+# You may well run out of memory with this default setup.
+$ podman machine init --cpus=2 --memory=4096
+
+# Start podman machine
+$ podman machine start
+
+# Build container
+$ cd your_repo
+$ podman-compose build
+
+# Start dev container with JupyterLab
+$ MODE=jupyterlab podman-compose up
+
+# To stop the dev container
+# (in another terminal window or tab)
+$ cd your_repo
+$ podman-compose down
+
+# To stop podman
+$ podman machine stop
+```
+
+Check out [Podman docs](https://docs.podman.io/en/latest/index.html) for more information and instructions. 
+
+*Docker Desktop + Visual Studio Code*
+
+[Docker Desktop](https://www.docker.com/) is an open core tool for managing Docker containers. Please note that most non-personal use of Docker Desktop now requires paid license subscription.
+
+To use the template with docker desktop, install and start docker desktop according to the instructions. VSC Extensions work with Docker Desctop with default settings.
+
+Visual Studio Code is an IDE that supports container development. Install VSC and Dev Containers Extension. When you open your repository in VSC, it automatically detects `.devcontainer/devcontianer.json` and suggests opening the repository in a container. Alternatively, press `cmd/ctrl shift P`, type `Remote-Container: Rebuild and Reopen in Container` and press enter. VSC builds the container and attaches to it. 
+
+
+### Working offline:
+
+The repository allows developing and running ML models completely offline.
+
+Steps to offline install:
+
+0. Clone your repo on a network connected device or use codespaces.
+1. Add required python packages to `requirements/requirements.in`. Try to include all packages you might require, because adding them later without internet access is rather difficult.
+2. Build the image, and within the `requirements` folder run the script `./update_requirements.sh`. 
+3. Rebuild the image.
+4. Pull the image and transfer it to the offline device with Podman requirements installed.
+5. Start container in the `jupyterlab` mode with your choice of container tools.
+
+The API works offline, too, but requires network access for external clients.
+
 # Prerequisites
 
-Docker, GitHub Codespaces or Python >3.10
+The template was developed and tested with:
 
-Note: Default python version in this devcontainer is 3.10.6
+    GitHub Codespaces
 
-Optional:
+and MacBook Pro M1 & macOS Ventura 13.2.1 with:
 
-- Docker desktop 4.15.0 (93002)
-- Visual studio code
-  - VSC 1.74.0
-  - VSC Dev Containers Extension v0.245.2 (latest version has issues with MacOS & M1)
+    Docker desktop 4.15.0 (93002)
+    VSC 1.74.0
+    VSC Dev Containers Extension v0.245.2
 
-# Getting started:
+and MacBook Pro M1 & macOS Ventura 13.2.1 with:
 
-This chapter explains how to Initialize new repository using this template. 
+    podman-desktop 1.1.0
+    hyperkit 0.20210107
+    podman 4.5.1
+    podman-compose 1.0.6
+    docker 24.0.2
+    docker-compose 2.18.1
 
-## Setup git repository using template
-
-0.  (Create [GitHub account](https://github.com/) if you do not have one
-    already.
-1.  Sign into your GitHub homepage
-2.  Go to
-    [github.com/City-of-Helsinki/analytics_template](https://github.com/City-of-Helsinki/analytics_template)
-    and click the green button that says ‘Use this template’.
-3.  Give your project a name. Do not use the dash symbol ‘-’, but rather
-    the underscore ’\_’, because the name of the repo will become the
-    name of your Python module.
-4.  If you are creating a project for your organization, change the
-    owner of the repo. From the drop down bar, select your organization
-    GitHub account (e.g. City-of-Helsinki). You need to be included as a
-    team member to the GitHub of the organization.
-5.  Define your project publicity (you can change this later, but most
-    likely you want to begin with a private repo).
-6.  Click ‘Create repository from template’
-
-# Development environment setup
-
-### Codespaces
-
-If your organization has
-[Codespaces](https://github.com/features/codespaces) enabled (requires
-GitHub Enterprise & Azure subscription), you can do development using
-Visual Studio Code and you are now ready to begin development. Just
-launch the repository in a codespace, and a dev container is
-automatically set up!
-
-#### Using this template repository as base for your analytics project. 
-
-1. Open this repository in GitHub.
-2. Click on the "Use this template" button, which is located next to the "Clone or download" button.
-3. GitHub will then prompt you to select the repository name, description, and visibility for your new repository based on the template you've chosen. Customize these options to fit your needs.
-4. Click the "Create repository from template" button.
-5. GitHub will create a new repository for you, based on the template you've chosen.
-
-
-#### Using GitHub codespaces environment for analytics and development.
-
-1. Go to GitHub page of your newly created repository.
-2. Click on the "Code" button to open the dropdown menu.
-3. In the dropdown menu, select "Open with CodeSpaces." This will open the CodeSpaces setup page.
-4. After clicking the "Create Codespace" button, GitHub will then create your CodeSpace environment, which may take a few minutes depending on your configuration options.
-5. Once your CodeSpace environment is ready, you can find it under Code-menu. This will launch a web-based version of Visual Studio Code, which you can use to edit and run your code in the CodeSpace environment.
-
-
-### Local vscode with python
-
-Open cloned repository folder in Visual Studio Code. Try to execute any python script. 
-Virtual environment installation will be prompted. Follow instructions and Visual Studio Code will setup python environment for you.
-
-### Advanced setup: command line setup in local environment:
-
-If you choose not to use codespaces of IDE, such as Visual Studio Code, you can setup this project from command line using this instruction.
-
-0. Clone repository to your workstation.
-1. Create virtual environment: `python3 -m venv venv`
-2. Activate virtualenv: `source venv/bin/activate`
-3. Install pip-tools: `pip install pip-tools`
-4. Compile requirements:
-    `update_requirements.sh`
-5. Install requirements: `pip install -r requirements.txt` 
-6. Create an ipython kernel for running the notebooks:
-    `python -m ipykernel install --user --name analytics-env`
-7. Start jupyterlab: `jupyter-lab`
+Additional configuration may be required for other systems.
 
 # Analytics and development
 
@@ -102,7 +140,7 @@ control to keep your data safe.
 
 ## Notebooks
 
-Do your analytics work in nbs/00_core.ipynb.
+Do your analytics work in nbs/00_core.ipynb. You may add or rename notebooks as you wish, but use of running number prefix is recommended for organizing your work.
 
 Optionally you can define your readme in nbs/index.ipynb. See next chapter for details.
 
@@ -140,7 +178,7 @@ Run nbdev_clean to remove metadata from notebooks for cleaner commits.
 ## Dependencies
 
 Add library dependencies to requirements.in and use update_requirements.sh to construct requirement.txt. 
-File dev-requirements.in is intended for project development environment requirements. 
+File dev-requirements.in is intended for project development environment requirements.
 
 ### Notes to codespaces users
 


### PR DESCRIPTION
- Default development environment still Codespaces with VSC setup
- Switch default local container runtime tool from Docker Desktop to Podman.
- Now two instructed ways to work on local environments: Podman + Jupyterlab, and Docker + VSC